### PR TITLE
Link javadocs to FlowPoweredMath & GSON

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,9 @@ tasks.javadoc {
     options {
         (this as? StandardJavadocDocletOptions)?.apply {
             links(
-                "https://docs.oracle.com/javase/8/docs/api/"
+                "https://docs.oracle.com/javase/8/docs/api/",
+                "https://javadoc.io/doc/com.flowpowered/flow-math/1.0.3/",
+                "https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/",
             )
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,7 @@ tasks.javadoc {
             links(
                 "https://docs.oracle.com/javase/8/docs/api/",
                 "https://javadoc.io/doc/com.flowpowered/flow-math/1.0.3/",
-                "https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/",
+                "https://javadoc.io/doc/com.google.code.gson/gson/2.8.0/",
             )
         }
     }


### PR DESCRIPTION
A comparison:
![image](https://github.com/BlueMap-Minecraft/BlueMapAPI/assets/22576047/fdc316f9-31e4-4504-9435-714154aa5ba7)

Instead of the long `com.flowpowered.math.vector.Vector2d`, it now just lists [`Vector2d`](https://javadoc.io/doc/com.flowpowered/flow-math/1.0.3/com/flowpowered/math/vector/Vector2d.html).
But notice that it also actually links to the official FlowPowered Math JavaDoc!

I have tested that this works locally.